### PR TITLE
Fix API controllers and preload associations to reduce N+1

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -16,10 +16,10 @@ class Api::V1::CategoriesController < ApplicationController
   end
 
   def update
-    if CategoryService::Updater.call(@category, product_params)
+    if CategoryService::Updater.call(@category, category_params)
       render json: serialize_resource(@category, serializer), status: :ok
     else
-      render json: error_response(@category, 'Failed to update the product'), status: :unprocessable_entity
+      render json: error_response(@category, 'Failed to update the category'), status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/product_details_controller.rb
+++ b/app/controllers/api/v1/product_details_controller.rb
@@ -3,8 +3,6 @@ class Api::V1::ProductDetailsController < ApplicationController
   before_action :set_product, only: %i[index]
 
   def index
-    options = {}
-    render json: serialize_resources(data, serializer, options), status: :ok
     @product_details = ProductDetailService::Retriever.call(@product.product_details, params)
     render_collection(paginate(@product_details), serializer, ProductDetailService::Helper.index_options)
   end

--- a/app/controllers/api/v1/requisitions_controller.rb
+++ b/app/controllers/api/v1/requisitions_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::RequisitionsController < ApplicationController
   private
 
   def set_requisition
-    @requisition = Requisition::Reader.call(params[:id])
+    @requisition = RequisitionService::Reader.call(params[:id])
   end
 
   def serializer

--- a/app/services/category_service/retriever.rb
+++ b/app/services/category_service/retriever.rb
@@ -9,6 +9,13 @@ module CategoryService
     def call
       apply_filters
       apply_sorting
+      attach_images_to_result
+    end
+
+    private
+
+    def attach_images_to_result
+      @scope.with_attached_image
     end
   end
 end

--- a/app/services/product_detail_service/retriever.rb
+++ b/app/services/product_detail_service/retriever.rb
@@ -27,7 +27,7 @@ module ProductDetailService
     private
 
     def attach_images_to_result
-      @scope.with_attached_images
+      @scope.includes(:product, :price_details, :suppliers, :tags).with_attached_images
     end
   end
 end

--- a/app/services/product_service/retriever.rb
+++ b/app/services/product_service/retriever.rb
@@ -14,7 +14,7 @@ module ProductService
     private
 
     def attach_images_to_result
-      @scope.with_attached_images
+      @scope.includes(:categories, :tags, :product_details).with_attached_images
     end
 
   end


### PR DESCRIPTION
### Motivation
- Fix incorrect controller behavior and parameter usage that caused wrong renders and inconsistent error messages in category and product detail endpoints.
- Replace a direct model reader reference with the service reader for requisitions to keep service-layer consistency.
- Reduce N+1 query and attachment lookups by preloading frequently accessed associations in retriever services.

### Description
- Removed an extraneous render from `Api::V1::ProductDetailsController#index` and now fetches product details via `ProductDetailService::Retriever` before rendering. (updated `app/controllers/api/v1/product_details_controller.rb`)
- Corrected `Api::V1::CategoriesController#update` to use `category_params` and fixed the error message to reference categories. (updated `app/controllers/api/v1/categories_controller.rb`)
- Switched `RequisitionsController#set_requisition` to use the service reader `RequisitionService::Reader` for consistency. (updated `app/controllers/api/v1/requisitions_controller.rb`)
- Eager-loaded associations in retrievers to reduce N+1 and attachment lookups: `ProductService::Retriever` now includes `:categories, :tags, :product_details`, `ProductDetailService::Retriever` includes `:product, :price_details, :suppliers, :tags`, and `CategoryService::Retriever` now attaches images via `attach_images_to_result`. (updated `app/services/product_service/retriever.rb`, `app/services/product_detail_service/retriever.rb`, `app/services/category_service/retriever.rb`)

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69821bc087408333886dfc18edd8aa8d)